### PR TITLE
feat: navigator 메인 탭 네 개에서만 보여주기

### DIFF
--- a/src/pages/Layout.tsx
+++ b/src/pages/Layout.tsx
@@ -1,15 +1,20 @@
 import Navigator from '@/common/components/Navigator';
 import { css } from '@styled-system/css';
-import { Outlet } from 'react-router';
+import { Outlet, useLocation } from 'react-router';
 
 /**
  * 모든 페이지들이 공유하는 Layout이에요
  */
 const Layout = () => {
+  const { pathname } = useLocation();
+
+  const visiblePaths = ['/', '/pick', '/chat', '/my'];
+  const showNav = visiblePaths.includes(pathname);
+
   return (
     <div className={css({ position: 'fixed', top: 0, right: 0, bottom: 0, left: 0 })}>
       <Outlet />
-      <Navigator />
+      {showNav && <Navigator />}
     </div>
   );
 };


### PR DESCRIPTION
- StackFlow -> React Router## ❗ 연관 이슈
## 📌 내용
네비게이터를 특정 페이지에서만 보이게끔 숮정했습니다

## ☑️ 체크 사항 & 논의 사항
- 더 좋은 방법이 있을까요?
- 네비게이터가 저 네 개의 탭에서만 보이는 게 맞나? 맞겟지
- [x] 이건뭐임 체크박스구나