### PR TITLE
[상품정보 / #59] 상품 정보 페이지 헤더 구현 구현 !

### DIFF
--- a/src/common/components/SafeArea/index.tsx
+++ b/src/common/components/SafeArea/index.tsx
@@ -6,17 +6,6 @@ import * as s from './style.css';
  * 모바일에서 봤을 때 짤림 영역이 (아마도)없는 AppScreen
  */
 const SafeArea = ({ children }: PropsWithChildren) => {
-  return (
-    <div
-      className={s.Container}
-      style={{
-        top: 'calc(env(safe-area-inset-top))',
-        left: 'calc(env(safe-area-inset-left))',
-        right: 'calc(env(safe-area-inset-right))',
-      }}
-    >
-      {children}
-    </div>
-  );
+  return <div className={s.Container}>{children}</div>;
 };
 export default SafeArea;

--- a/src/common/components/SafeArea/style.css.ts
+++ b/src/common/components/SafeArea/style.css.ts
@@ -3,4 +3,7 @@ import { css } from '@styled-system/css';
 export const Container = css({
   position: 'absolute',
   bottom: 0,
+  top: 'calc(env(safe-area-inset-top))',
+  left: 'calc(env(safe-area-inset-left))',
+  right: 'calc(env(safe-area-inset-right))',
 });

--- a/src/features/detail/components/DetailHeader/index.tsx
+++ b/src/features/detail/components/DetailHeader/index.tsx
@@ -7,12 +7,7 @@ const DetailHeader = () => {
   const goBack = () => navigate(-1);
   // TODO: Action 추가
   return (
-    <header
-      className={s.Container}
-      style={{
-        top: 'calc(env(safe-area-inset-top))',
-      }}
-    >
+    <header className={s.Container}>
       <button className={`mgc_left_line ${s.BackButton}`} onClick={goBack} aria-label="Go back" />
       <div className={s.RightSide}>
         <button className={`${s.RightButton} mgc_share_3_fill`} />

--- a/src/features/detail/components/DetailHeader/index.tsx
+++ b/src/features/detail/components/DetailHeader/index.tsx
@@ -1,0 +1,24 @@
+import { useNavigate } from 'react-router';
+import * as s from './style.css';
+
+const DetailHeader = () => {
+  const navigate = useNavigate();
+
+  const goBack = () => navigate(-1);
+  // TODO: Action 추가
+  return (
+    <header
+      className={s.Container}
+      style={{
+        top: 'calc(env(safe-area-inset-top))',
+      }}
+    >
+      <button className={`mgc_left_line ${s.BackButton}`} onClick={goBack} />
+      <div className={s.RightSide}>
+        <button className={`${s.RightButton} mgc_share_3_fill`} />
+        <button className={`${s.RightButton} mgc_more_2_fill`} />
+      </div>
+    </header>
+  );
+};
+export default DetailHeader;

--- a/src/features/detail/components/DetailHeader/index.tsx
+++ b/src/features/detail/components/DetailHeader/index.tsx
@@ -13,7 +13,7 @@ const DetailHeader = () => {
         top: 'calc(env(safe-area-inset-top))',
       }}
     >
-      <button className={`mgc_left_line ${s.BackButton}`} onClick={goBack} />
+      <button className={`mgc_left_line ${s.BackButton}`} onClick={goBack} aria-label="Go back" />
       <div className={s.RightSide}>
         <button className={`${s.RightButton} mgc_share_3_fill`} />
         <button className={`${s.RightButton} mgc_more_2_fill`} />

--- a/src/features/detail/components/DetailHeader/style.css.ts
+++ b/src/features/detail/components/DetailHeader/style.css.ts
@@ -1,0 +1,28 @@
+import { css } from '@styled-system/css';
+
+export const Container = css({
+  position: 'absolute',
+  right: 0,
+  left: 0,
+  p: '0.625rem 1.25rem',
+  d: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  color: '100',
+});
+
+export const BackButton = css({
+  fontSize: '2.25rem',
+  cursor: 'pointer',
+});
+
+export const RightSide = css({
+  d: 'flex',
+  alignItems: 'center',
+  gap: '0.625rem',
+});
+
+export const RightButton = css({
+  fontSize: '1.5rem',
+  cursor: 'pointer',
+});

--- a/src/features/detail/components/DetailHeader/style.css.ts
+++ b/src/features/detail/components/DetailHeader/style.css.ts
@@ -4,6 +4,7 @@ export const Container = css({
   position: 'absolute',
   right: 0,
   left: 0,
+  top: 'calc(env(safe-area-inset-top))',
   p: '0.625rem 1.25rem',
   d: 'flex',
   justifyContent: 'space-between',

--- a/src/pages/DetailPage/index.tsx
+++ b/src/pages/DetailPage/index.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router';
 import * as s from './style.css';
 
 import useGetPostDetail from '@/features/detail/hooks/apis/useGetPostDetail';
+import DetailHeader from '@/features/detail/components/DetailHeader';
 
 const DetailPage = () => {
   const { id } = useParams();
@@ -14,14 +15,7 @@ const DetailPage = () => {
 
   return (
     <div className={s.Container}>
-      <div
-        className={s.Header}
-        style={{
-          top: 'calc(env(safe-area-inset-top))',
-        }}
-      >
-        상단바 상단바 상단바
-      </div>
+      <DetailHeader />
       <img
         className={s.Image}
         src={'https://crimsonstore.co.kr/web/product/tiny/202411/215b536247ca28c1e97dd6a0d0d6d23a.jpg'}

--- a/src/pages/DetailPage/style.css.ts
+++ b/src/pages/DetailPage/style.css.ts
@@ -6,12 +6,6 @@ export const Container = css({
   display: 'relative',
 });
 
-export const Header = css({
-  position: 'absolute',
-  right: 0,
-  left: 0,
-});
-
 export const Image = css({
   width: '100%',
   height: '24.375rem',


### PR DESCRIPTION
## ❗ 연관 이슈

- Resolves #59 
- #54 
<!-- 관련된 이슈가 있다면 작성해주세요. ex) - #이슈번호 -->

## 📌 내용

<img width="345" alt="Screenshot 2025-07-05 at 1 22 19 AM" src="https://github.com/user-attachments/assets/56e98935-b07e-4610-9d59-78e1b2e5e784" />

- 짜잔
- 아 오늘 일 너무 많이 했다
- api 연결은 되어있지만 사진이 안나오는 이슈로 일단 목업 사진을 박아뒀어요
	- 공유버튼이랑 저 더보기 버튼은 정확히 어떤 액션이 있는지 알아보고 구현할 예정

<!-- PR에 대한 소개와, 어떤 기능 / 어떤 버그 픽스 구현이 있는지 설명해주세요.
논의가 필요한 지점이나 고려할 점이 있다면 작성해주세요. -->

## ☑️ 체크 사항 & 논의 사항

<!-- 체크해봐야할 지점을 작성해주세요. -->

- [ ] 디자인 일치율 100%인가요 ?? ??? ???
- [ ] 그냥 체크 눌러줘요