### PR TITLE
[#60] feat: 데스크탑에서도 모바일처럼 보이게!

### DIFF
--- a/panda.config.ts
+++ b/panda.config.ts
@@ -1,5 +1,12 @@
 import { defineConfig } from '@pandacss/dev';
 
+const PANDA_CSS_CONSTANTS = {
+  NAVIGATOR_HEIGHT: { value: '97px' },
+  HOME_HEADER_HEIGHT: { value: '52px' },
+  DETAIL_PAGE_NAVIGATOR_HEIGHT: { value: '6.75rem' },
+  MAX_WIDTH: { value: '700px' },
+};
+
 export default defineConfig({
   // Whether to use css reset
   preflight: true,
@@ -29,9 +36,14 @@ export default defineConfig({
           '80': { value: 'rgba(255, 255, 255, 0.80)' },
           '54': { value: 'rgba(255, 255, 255, 0.54)' },
         },
+        lineHeights: {
+          normal: { value: '1.2' },
+        },
         zIndex: {
           navigator: { value: 500 },
         },
+        sizes: PANDA_CSS_CONSTANTS,
+        spacing: PANDA_CSS_CONSTANTS,
       },
     },
   },

--- a/src/common/components/Navigator/index.tsx
+++ b/src/common/components/Navigator/index.tsx
@@ -1,6 +1,5 @@
 import { Link, useLocation } from 'react-router';
 import * as s from './style.css';
-import { NAVIGATOR_HEIGHT_PX } from '@/libs/constants/sizes';
 
 const MENU_LIST = [
   {
@@ -34,7 +33,7 @@ const Navigator = () => {
   const { pathname } = useLocation();
 
   return (
-    <nav className={s.Container} style={{ height: `${NAVIGATOR_HEIGHT_PX}px` }}>
+    <nav className={s.Container}>
       {MENU_LIST.map(({ label, path, selectedClassName, unSelectedClassName }) => {
         const selected = pathname === path;
         return (

--- a/src/common/components/Navigator/style.css.ts
+++ b/src/common/components/Navigator/style.css.ts
@@ -5,6 +5,7 @@ export const Container = css({
   bottom: 0,
   left: 0,
   right: 0,
+  height: 'NAVIGATOR_HEIGHT',
   zIndex: 'navigator', // Token으로 정의해뒀삽니다. 루트의 panda.config.ts 참고. 이거 덮고 싶으면 더 위에 컴포넌트 만들면 됨
   width: 'full', // 100%라는 뜻 (Panda CSS에서만 쓰이는 키워드임)
   display: 'flex',

--- a/src/common/components/Navigator/style.css.ts
+++ b/src/common/components/Navigator/style.css.ts
@@ -1,7 +1,7 @@
 import { css, cva } from '@styled-system/css';
 
 export const Container = css({
-  position: 'fixed',
+  position: 'absolute',
   bottom: 0,
   left: 0,
   right: 0,

--- a/src/libs/constants/sizes.ts
+++ b/src/libs/constants/sizes.ts
@@ -1,3 +1,0 @@
-export const NAVIGATOR_HEIGHT_PX = 97;
-export const HOME_HEADER_HEIGHT_PX = 52;
-export const DETAIL_PAGE_NAVIGATOR_HEIGHT_REM = 6.75;

--- a/src/pages/DetailPage/index.tsx
+++ b/src/pages/DetailPage/index.tsx
@@ -7,7 +7,6 @@ import DetailHeader from '@/features/detail/components/DetailHeader';
 import ImageContainer from '@/features/detail/components/ImageContainer';
 import UserInfo from '@/features/detail/components/UserInfo';
 import PostContent from '@/features/detail/components/PostContent';
-import { DETAIL_PAGE_NAVIGATOR_HEIGHT_REM } from '@/libs/constants/sizes';
 
 const DetailPage = () => {
   const { id } = useParams();
@@ -20,7 +19,7 @@ const DetailPage = () => {
   return (
     <div className={s.Container}>
       <DetailHeader />
-      <div className={s.ScrollContainer} style={{ paddingBottom: `${DETAIL_PAGE_NAVIGATOR_HEIGHT_REM}rem` }}>
+      <div className={s.ScrollContainer}>
         <ImageContainer images={data.images} />
         <div className={s.ContentContainer}>
           <UserInfo userData={data.writer} />

--- a/src/pages/DetailPage/style.css.ts
+++ b/src/pages/DetailPage/style.css.ts
@@ -10,6 +10,7 @@ export const ScrollContainer = css({
   width: 'full',
   height: 'full',
   overflowY: 'auto',
+  paddingBottom: 'DETAIL_PAGE_NAVIGATOR_HEIGHT',
 });
 
 export const ContentContainer = css({

--- a/src/pages/HomePage/index.tsx
+++ b/src/pages/HomePage/index.tsx
@@ -7,7 +7,6 @@ import WriteButton from '@/features/home/components/WriteButton';
 
 import * as s from './style.css';
 
-import { HOME_HEADER_HEIGHT_PX, NAVIGATOR_HEIGHT_PX } from '@/libs/constants/sizes';
 import Banner from '@/features/home/components/Banner';
 
 const HomePage = () => {
@@ -16,16 +15,11 @@ const HomePage = () => {
   return (
     <SafeArea>
       <MainTopBar />
-      <div
-        className={s.Container}
-        style={{
-          height: `calc(100% - ${NAVIGATOR_HEIGHT_PX}px - ${HOME_HEADER_HEIGHT_PX}px)`,
-        }}
-      >
+      <div className={s.Container}>
         <Banner />
         <RecentList />
       </div>
-      <div className={s.WriteButtonContainer} style={{ bottom: `calc(1.06rem + ${NAVIGATOR_HEIGHT_PX}px)` }}>
+      <div className={s.WriteButtonContainer}>
         <WriteButton onClick={() => navigate('/post')} />
       </div>
     </SafeArea>

--- a/src/pages/HomePage/style.css.ts
+++ b/src/pages/HomePage/style.css.ts
@@ -1,6 +1,7 @@
 import { css } from '@styled-system/css';
 
 export const Container = css({
+  height: 'calc(100% - {sizes.NAVIGATOR_HEIGHT} - {sizes.HOME_HEADER_HEIGHT})',
   overflowY: 'auto',
   paddingBottom: '1rem',
   display: 'flex',
@@ -13,4 +14,5 @@ export const Container = css({
 export const WriteButtonContainer = css({
   position: 'absolute',
   right: '0.99rem',
+  bottom: 'calc(1.06rem + {spacing.NAVIGATOR_HEIGHT})',
 });

--- a/src/pages/Layout/index.tsx
+++ b/src/pages/Layout/index.tsx
@@ -1,6 +1,7 @@
 import Navigator from '@/common/components/Navigator';
-import { css } from '@styled-system/css';
 import { Outlet, useLocation } from 'react-router';
+
+import * as s from './style.css';
 
 /**
  * 모든 페이지들이 공유하는 Layout이에요
@@ -12,9 +13,11 @@ const Layout = () => {
   const showNav = visiblePaths.includes(pathname);
 
   return (
-    <div className={css({ position: 'fixed', top: 0, right: 0, bottom: 0, left: 0 })}>
-      <Outlet />
-      {showNav && <Navigator />}
+    <div className={s.FlexContainer}>
+      <div className={s.RelativeContainer}>
+        <Outlet />
+        {showNav && <Navigator />}
+      </div>
     </div>
   );
 };

--- a/src/pages/Layout/style.css.ts
+++ b/src/pages/Layout/style.css.ts
@@ -1,0 +1,15 @@
+import { css } from '@styled-system/css';
+
+export const FlexContainer = css({
+  position: 'fixed',
+  top: 0,
+  right: 0,
+  bottom: 0,
+  left: 0,
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'stretch',
+});
+
+// TODO: maxW 검토
+export const RelativeContainer = css({ position: 'relative', width: 'full', height: 'full', maxW: '700px' });

--- a/src/pages/Layout/style.css.ts
+++ b/src/pages/Layout/style.css.ts
@@ -11,5 +11,4 @@ export const FlexContainer = css({
   alignItems: 'stretch',
 });
 
-// TODO: maxW 검토
-export const RelativeContainer = css({ position: 'relative', width: 'full', height: 'full', maxW: '700px' });
+export const RelativeContainer = css({ position: 'relative', width: 'full', height: 'full', maxW: 'MAX_WIDTH' });


### PR DESCRIPTION
## ❗ 연관 이슈

- Resolves #60 
<!-- 관련된 이슈가 있다면 작성해주세요. ex) - #이슈번호 -->

## 📌 내용

<img width="1512" alt="Screenshot 2025-07-09 at 12 04 38 PM" src="https://github.com/user-attachments/assets/cbed1ec9-e85c-4c60-b3bc-d71c6eaa873a" />


- 짜잔
- maxWidth를 지정해서 데스크탑 뷰에서도 과하게 늘어나지 않고 모바일 뷰처럼 보이게 했삼
- PandaCSS token을 사용해서 여러 Contants들을 관리하기로 함!! 드디어 코파일럿 잔소리에서 달출
	- 하는 김에 `lineHeight: 'normal'` 속성도 1.2를 기본값으로 세팅해서 이제 피그마대로 css 옮겨도 될꺼에요

<!-- PR에 대한 소개와, 어떤 기능 / 어떤 버그 픽스 구현이 있는지 설명해주세요.
논의가 필요한 지점이나 고려할 점이 있다면 작성해주세요. -->

## ☑️ 체크 사항 & 논의 사항

<!-- 체크해봐야할 지점을 작성해주세요. -->

- maxWidth를 일단 700px로 지정해두긴 했는데 개인적으로 550px 정도가 제일 이쁘긴 함...
	- 근데 문제는 갤럭시 폴드 이런 친구들 화면 너비가 690px 정도 되는거 같음
	- 디자이너들과 함께 적정 화면 너비 논의해봐야 할 필요 있ㅅ음 굉씨 생각은 어때요
- [x] 페이지 돌아댕길때 뭔가 어색한 부분이나 사이드 이펙트는 없는지
- [ ] 이거 양 옆은 배경색 넣어주는게 나으려나