### PR TITLE
[#32] 홈화면 디자인 수정

### DIFF
--- a/src/common/components/ItemTokenList/index.tsx
+++ b/src/common/components/ItemTokenList/index.tsx
@@ -1,11 +1,27 @@
-import type { ItemInfoInterface } from '@/features/detail/types';
 import Token from '@/common/components/Token';
-import { TAG_TYPES_MAP, type TagType } from '@/libs/types/item';
+import {
+  TAG_TYPES_MAP,
+  type Color,
+  type ProductType,
+  type Quality,
+  type Size,
+  type TagType,
+  type TradeMethods,
+  type TransactionType,
+} from '@/libs/types/item';
 
 interface Props {
-  itemInfo: ItemInfoInterface;
+  itemInfo: {
+    productTypes: ProductType[];
+    transactionTypes: TransactionType[];
+    color: Color;
+    tradeMethods: TradeMethods[];
+    quality: Quality;
+    size: Size;
+  } & Record<string, unknown>;
+  showAll?: boolean;
 }
-const ItemTokenList = ({ itemInfo }: Props) => {
+const ItemTokenList = ({ itemInfo, showAll = true }: Props) => {
   const tags: TagType[] = [
     ...itemInfo.transactionTypes,
     ...itemInfo.productTypes,
@@ -14,12 +30,15 @@ const ItemTokenList = ({ itemInfo }: Props) => {
     itemInfo.quality,
     itemInfo.size,
   ];
+  const showTags = showAll ? tags : tags.slice(0, 4);
+  const noneShownCount = tags.length - showTags.length;
 
   return (
     <>
-      {tags.map(type => (
+      {showTags.map(type => (
         <Token key={type}>{TAG_TYPES_MAP[type]}</Token>
       ))}
+      {!showAll && noneShownCount > 0 && <Token>+{noneShownCount}</Token>}
     </>
   );
 };

--- a/src/common/components/Token/style.css.ts
+++ b/src/common/components/Token/style.css.ts
@@ -9,4 +9,5 @@ export const Container = css({
   fontSize: '0.625rem',
   fontWeight: 500,
   letterSpacing: '-0.025rem',
+  flexShrink: 0,
 });

--- a/src/features/home/components/ItemCard/index.tsx
+++ b/src/features/home/components/ItemCard/index.tsx
@@ -2,14 +2,16 @@ import { Link } from 'react-router';
 
 import * as s from './style.css';
 
-import { PRODUCT_TYPES_MAP } from '@/libs/types/item';
 import type { ItemInterface } from '@/features/home/types';
-import Token from '@/common/components/Token';
+import ItemTokenList from '@/common/components/ItemTokenList';
 
 interface Props {
   data: ItemInterface;
 }
 const ItemCard = ({ data }: Props) => {
+  const isRental = data.transactionTypes.includes('RENTAL');
+  const isSale = data.transactionTypes.includes('SALE');
+
   return (
     <Link className={s.Container} to={`/detail/${data.itemId}`}>
       <img className={s.Image} src={data.thumbnail} aria-hidden />
@@ -17,22 +19,25 @@ const ItemCard = ({ data }: Props) => {
         <div className={s.Header}>
           <h2 className={s.Title}>{data.title}</h2>
           <div className={s.Price}>
-            <div className={s.PriceItem}>
-              <label>대여료</label>
-              <p>{data.rentalFee.toLocaleString()}원</p>
-            </div>
-            <div className={s.PriceItem}>
-              <label>보증금</label>
-              <p>{data.deposit.toLocaleString()}원</p>
-            </div>
+            {isRental && (
+              <div className={s.PriceItem}>
+                <label>대여</label>
+                <p>{data.rentalFee.toLocaleString()}원</p>
+                <p>
+                  <label>보증금</label>
+                  {data.deposit.toLocaleString()}원
+                </p>
+              </div>
+            )}
+            {isSale && (
+              <div className={s.PriceItem}>
+                <label>판매</label>
+                <p>{data.salePrice.toLocaleString()}원</p>
+              </div>
+            )}
           </div>
         </div>
         <div className={s.Footer}>
-          <div className={s.Tokens}>
-            {data.productTypes.map((type, index) => (
-              <Token key={`${type}-${index}`}>{PRODUCT_TYPES_MAP[type]}</Token>
-            ))}
-          </div>
           <div className={s.Interactions}>
             <div className={s.InteractionItem}>
               <span className="mgc_heart_fill" />
@@ -42,6 +47,13 @@ const ItemCard = ({ data }: Props) => {
               <span className="mgc_chat_2_fill" />
               <p>{data.chatRoomCount}</p>
             </div>
+          </div>
+          <div className={s.Tokens}>
+            {/* TODO: API 수정 요청 */}
+            <ItemTokenList
+              showAll={false}
+              itemInfo={{ ...data, color: 'COLOR_OTHER', quality: 'BEST', size: 'L', tradeMethods: ['DIRECT'] }}
+            />
           </div>
         </div>
       </div>

--- a/src/features/home/components/ItemCard/style.css.ts
+++ b/src/features/home/components/ItemCard/style.css.ts
@@ -2,17 +2,18 @@ import { css } from '@styled-system/css';
 
 export const Container = css({
   w: 'full',
-  h: '6.25rem',
+  h: '6.5rem',
   display: 'flex',
   alignItems: 'stretch',
   gap: '1rem',
 });
 
 export const Image = css({
-  w: '6.25rem',
-  h: '6.25rem',
-  borderRadius: '12.5px',
+  w: '6.5rem',
+  h: '6.5rem',
+  borderRadius: '0.78125rem',
   objectFit: 'cover',
+  flexShrink: 0,
 });
 
 export const Info = css({
@@ -20,40 +21,49 @@ export const Info = css({
   display: 'flex',
   flexDir: 'column',
   justifyContent: 'space-between',
-  padding: '0.25rem 0',
+  padding: '0.125rem 0',
+  overflow: 'hidden',
 });
 
 export const Header = css({
   display: 'flex',
   flexDir: 'column',
   gap: '0.25rem',
+  alignItems: 'stretch',
 });
 
 export const Title = css({
   color: '100',
   fontSize: '1rem',
-  fontWeight: 500,
-  lineHeight: 1.2,
+  fontWeight: 400,
+  lineHeight: 'normal',
   letterSpacing: '-0.04rem',
+  lineClamp: 1,
 });
 
 export const Price = css({
   display: 'flex',
-  alignItems: 'center',
-  gap: '0.875rem',
-  height: '1.5625rem',
+  flexDir: 'column',
+  gap: '0.125rem',
 });
 
 export const PriceItem = css({
   display: 'flex',
-  alignItems: 'baseline',
-  gap: '0.25rem',
-  '& label': {
+  alignItems: 'center',
+  gap: '0.375rem',
+  '& > label': {
+    padding: '0.125rem 0.25rem',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    rounded: '0.25rem',
+    bgColor: 'systemGray4',
     color: '54',
-    fontSize: '0.875rem',
+    fontSize: '0.625rem',
     fontWeight: 500,
     lineHeight: 1.4,
-    letterSpacing: '-0.035rem',
+    letterSpacing: '-0.025rem',
+    flexShrink: 0,
   },
   '& p': {
     color: '100',
@@ -61,6 +71,15 @@ export const PriceItem = css({
     fontWeight: 600,
     lineHeight: 1.4,
     letterSpacing: '-0.04rem',
+    display: 'flex',
+    gap: '0.375rem',
+    alignItems: 'baseline',
+    '& > label': {
+      color: '54',
+      fontSize: '0.875rem',
+      fontWeight: 500,
+      letterSpacing: '-0.035rem',
+    },
   },
 });
 
@@ -68,18 +87,22 @@ export const Footer = css({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-between',
+  width: 'full',
+  gap: '0.25rem',
 });
 
 export const Tokens = css({
   display: 'flex',
   alignItems: 'center',
   gap: '0.25rem',
+  overflowX: 'auto',
 });
 
 export const Interactions = css({
   display: 'flex',
   alignItems: 'center',
-  gap: '0.875rem',
+  gap: '0.625rem',
+  flexShrink: 0,
 });
 
 export const InteractionItem = css({

--- a/src/libs/constants/index.ts
+++ b/src/libs/constants/index.ts
@@ -1,0 +1,1 @@
+export const MAX_PRICE = 999999;


### PR DESCRIPTION
## ❗ 연관 이슈

- #32
<!-- 관련된 이슈가 있다면 작성해주세요. ex) - #이슈번호 -->

## 📌 내용
<img width="332" height="722" alt="Screenshot 2025-07-18 at 4 55 29 PM" src="https://github.com/user-attachments/assets/35ba5ac1-a7c7-4148-a6fa-2487a00ced09" />

- 홈화면 정상화
- 바뀐 디자인 + 이상게시글에 대한 대응을 완료했음 www
	- 토큰 너무 많으면 +로 표시해주기
	- 대여료, 보증금, 판매가 다 표시 가능하게 해주기
	- 좋아요/댓글 영역이랑 토큰 영역이랑 순서 바꾸기 (피그마엔 섞여있는데 디자이너님들이 이걸로 통일해달래요)
	- 너무 긴 텍스트에 대한 대응 (사실 실제로 돌려보면 아직 깨져있을꺼임, 가격 상한 정해뿌면 해결될꺼에요)
<!-- PR에 대한 소개와, 어떤 기능 / 어떤 버그 픽스 구현이 있는지 설명해주세요.
논의가 필요한 지점이나 고려할 점이 있다면 작성해주세요. -->

## ☑️ 체크 사항 & 논의 사항

<!-- 체크해봐야할 지점을 작성해주세요. -->

- [ ] FigDesEql?