### PR TITLE
[#63] 제품 페이지 하단 바 구현 구현

### DIFF
--- a/panda.config.ts
+++ b/panda.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from '@pandacss/dev';
 const PANDA_CSS_CONSTANTS = {
   NAVIGATOR_HEIGHT: { value: '97px' },
   HOME_HEADER_HEIGHT: { value: '52px' },
-  DETAIL_PAGE_NAVIGATOR_HEIGHT: { value: '6.75rem' },
+  DETAIL_PAGE_NAVIGATOR_HEIGHT: { value: '6.375rem' },
   MAX_WIDTH: { value: '700px' },
   CHAT_ROOM_FOOTER_HEIGHT: { value: '102px' },
   CHAT_MAX_WIDTH: { value: '270px' },

--- a/src/common/components/Button/index.tsx
+++ b/src/common/components/Button/index.tsx
@@ -1,15 +1,17 @@
 import type { HTMLAttributes, PropsWithChildren } from 'react';
-import * as s from './style.css';
 import { cx } from '@styled-system/css';
+
+import * as s from './style.css';
 
 interface Props extends PropsWithChildren {
   mode?: 'main' | 'default' | 'back' | 'disabled';
   onClick?: () => void;
   style?: HTMLAttributes<HTMLDivElement>['style'];
+  className?: string;
 }
-const Btn = ({ children, mode = 'default', onClick, style }: Props) => {
+const Btn = ({ children, mode = 'default', onClick, style, className }: Props) => {
   return (
-    <div className={s.Button({ mode })} style={style} onClick={onClick}>
+    <div className={cx(s.Button({ mode }), className)} style={style} onClick={onClick}>
       {children}
     </div>
   );

--- a/src/common/components/Button/index.tsx
+++ b/src/common/components/Button/index.tsx
@@ -1,5 +1,6 @@
 import type { HTMLAttributes, PropsWithChildren } from 'react';
 import * as s from './style.css';
+import { cx } from '@styled-system/css';
 
 interface Props extends PropsWithChildren {
   mode?: 'main' | 'default' | 'back' | 'disabled';

--- a/src/features/detail/components/BottomActions/index.tsx
+++ b/src/features/detail/components/BottomActions/index.tsx
@@ -24,8 +24,8 @@ const PickButton = ({ type, index, salePrice, deposit, rentalFee }: PickButtonPr
   };
 
   return (
-    <button className={s.PickButton({ color })} onClick={handlePickClick}>
-      <label>{label}</label>
+    <button className={s.PickButton({ color })} onClick={handlePickClick} aria-label={`${label}, ${priceText}`}>
+      <span>{label}</span>
       <p>{priceText}</p>
     </button>
   );

--- a/src/features/detail/components/BottomActions/index.tsx
+++ b/src/features/detail/components/BottomActions/index.tsx
@@ -1,0 +1,19 @@
+import Btn from '@/common/components/Button';
+
+import * as s from './style.css';
+
+const BottomActions = () => {
+  // TODO: 실제 액션 추가
+  return (
+    <div className={s.Container}>
+      <Btn color="softgray" className={s.ChatButton}>
+        <span className="mgc_chat_2_fill" />
+        <p>채팅</p>
+      </Btn>
+      <Btn color="main" className={s.SelectButton}>
+        대여일자선택
+      </Btn>
+    </div>
+  );
+};
+export default BottomActions;

--- a/src/features/detail/components/BottomActions/index.tsx
+++ b/src/features/detail/components/BottomActions/index.tsx
@@ -1,18 +1,69 @@
 import Btn from '@/common/components/Button';
 
 import * as s from './style.css';
+import type { TransactionType } from '@/libs/types/item';
+import type { ItemInfoInterface } from '@/features/detail/types';
 
-const BottomActions = () => {
+interface PickButtonProps {
+  type: TransactionType;
+  index: number;
+  salePrice: number;
+  deposit: number;
+  rentalFee: number;
+}
+const PickButton = ({ type, index, salePrice, deposit, rentalFee }: PickButtonProps) => {
+  const color = index === 0 ? 'red' : 'blue';
+  const label = type === 'RENTAL' ? '대여' : '구매';
+  const priceText =
+    type === 'RENTAL'
+      ? `대여료+보증금 ${(deposit + rentalFee).toLocaleString()}원`
+      : `판매가 ${salePrice.toLocaleString()}원`;
+
+  const handlePickClick = () => {
+    alert(`${type} 선택`);
+  };
+
+  return (
+    <button className={s.PickButton({ color })} onClick={handlePickClick}>
+      <label>{label}</label>
+      <p>{priceText}</p>
+    </button>
+  );
+};
+
+interface Props {
+  itemInfo: ItemInfoInterface;
+}
+const BottomActions = ({ itemInfo }: Props) => {
+  const { transactionTypes, mine, salePrice, deposit, rentalFee } = itemInfo;
+
   // TODO: 실제 액션 추가
+  const handleChatClick = () => {
+    alert('채팅 연결');
+  };
+
   return (
     <div className={s.Container}>
-      <Btn color="softgray" className={s.ChatButton}>
+      <Btn color="softgray" className={s.ChatButton({ isMine: mine })} onClick={handleChatClick}>
         <span className="mgc_chat_2_fill" />
-        <p>채팅</p>
+        {mine && <p>채팅</p>}
       </Btn>
-      <Btn color="main" className={s.SelectButton}>
-        대여일자선택
-      </Btn>
+      {!mine && (
+        <div className={s.PickButtonContainer}>
+          {transactionTypes.map((type, index) => {
+            return (
+              <PickButton
+                key={type}
+                type={type}
+                index={index}
+                salePrice={salePrice}
+                deposit={deposit}
+                rentalFee={rentalFee}
+              />
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/features/detail/components/BottomActions/index.tsx
+++ b/src/features/detail/components/BottomActions/index.tsx
@@ -44,7 +44,7 @@ const BottomActions = ({ itemInfo }: Props) => {
 
   return (
     <div className={s.Container}>
-      <Btn color="softgray" className={s.ChatButton({ isMine: mine })} onClick={handleChatClick}>
+      <Btn className={s.ChatButton({ isMine: mine })} onClick={handleChatClick}>
         <span className="mgc_chat_2_fill" />
         {mine && <p>채팅</p>}
       </Btn>

--- a/src/features/detail/components/BottomActions/style.css.ts
+++ b/src/features/detail/components/BottomActions/style.css.ts
@@ -1,0 +1,34 @@
+import { css } from '@styled-system/css';
+
+export const Container = css({
+  position: 'fixed',
+  bottom: '0',
+  left: '0',
+  right: '0',
+  display: 'flex',
+  gap: '0.69rem',
+  px: '1rem',
+  pt: '1rem',
+  bgColor: 'systemGray6',
+  boxShadow: '0px 0px 4px 0px rgba(0, 0, 0, 0.25)',
+  roundedTop: '10px',
+  height: 'DETAIL_PAGE_NAVIGATOR_HEIGHT',
+});
+
+export const ChatButton = css({
+  flexShrink: 0,
+  width: '5.875rem',
+  display: 'flex',
+  gap: '0.625rem',
+  justifyContent: 'center',
+  alignItems: 'center',
+  '& span': {
+    fontSize: '1.25rem',
+    flexShrink: 0,
+  },
+});
+
+export const SelectButton = css({
+  flexGrow: 1,
+  flexBasis: 0,
+});

--- a/src/features/detail/components/BottomActions/style.css.ts
+++ b/src/features/detail/components/BottomActions/style.css.ts
@@ -1,34 +1,76 @@
-import { css } from '@styled-system/css';
+import { css, cva } from '@styled-system/css';
 
 export const Container = css({
   position: 'fixed',
   bottom: '0',
   left: '0',
   right: '0',
-  display: 'flex',
-  gap: '0.69rem',
-  px: '1rem',
-  pt: '1rem',
-  bgColor: 'systemGray6',
-  boxShadow: '0px 0px 4px 0px rgba(0, 0, 0, 0.25)',
-  roundedTop: '10px',
   height: 'DETAIL_PAGE_NAVIGATOR_HEIGHT',
+  display: 'flex',
+  gap: '0.87rem',
+  px: '1rem',
+  pt: '0.625rem',
+  bg: 'linear-gradient(180deg, rgba(28, 28, 30, 0.00) 0%, #1C1C1E 8.82%)',
+  roundedTop: '0.625rem',
 });
 
-export const ChatButton = css({
-  flexShrink: 0,
-  width: '5.875rem',
-  display: 'flex',
-  gap: '0.625rem',
-  justifyContent: 'center',
-  alignItems: 'center',
-  '& span': {
-    fontSize: '1.25rem',
+export const ChatButton = cva({
+  base: {
     flexShrink: 0,
+    height: '3.125rem',
+  },
+  variants: {
+    isMine: {
+      true: {
+        width: 'full',
+      },
+      false: {
+        width: '3.125rem',
+      },
+    },
   },
 });
 
-export const SelectButton = css({
+export const PickButtonContainer = css({
   flexGrow: 1,
-  flexBasis: 0,
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.87rem',
+  height: '3.125rem',
+});
+
+export const PickButton = cva({
+  base: {
+    flexGrow: 1,
+    flexBasis: 0,
+    flexDir: 'column',
+    gap: '0.25rem',
+    height: 'full',
+    overflow: 'hidden',
+    rounded: '0.375rem',
+    '& > label': {
+      color: '80',
+      fontSize: '1rem',
+      fontWeight: 500,
+      lineHeight: 'normal',
+      letterSpacing: '-0.04rem',
+    },
+    '& > p': {
+      color: '100',
+      fontSize: '0.75rem',
+      fontWeight: 600,
+      lineHeight: 'normal',
+      letterSpacing: '-0.03rem',
+    },
+  },
+  variants: {
+    color: {
+      red: {
+        bgColor: 'main',
+      },
+      blue: {
+        bgColor: '#3978FF',
+      },
+    },
+  },
 });

--- a/src/features/detail/components/BottomActions/style.css.ts
+++ b/src/features/detail/components/BottomActions/style.css.ts
@@ -48,7 +48,7 @@ export const PickButton = cva({
     height: 'full',
     overflow: 'hidden',
     rounded: '0.375rem',
-    '& > label': {
+    '& > span': {
       color: '80',
       fontSize: '1rem',
       fontWeight: 500,

--- a/src/pages/DetailPage/index.tsx
+++ b/src/pages/DetailPage/index.tsx
@@ -7,6 +7,7 @@ import ImageContainer from '@/features/detail/components/ImageContainer';
 import UserInfo from '@/features/detail/components/UserInfo';
 import PostContent from '@/features/detail/components/PostContent';
 import useGetItemDetail from '@/features/detail/apis/useGetItemDetail';
+import BottomActions from '@/features/detail/components/BottomActions';
 
 const DetailPage = () => {
   const { id } = useParams();
@@ -26,6 +27,7 @@ const DetailPage = () => {
           <PostContent itemInfo={data.itemInfo} />
         </div>
       </div>
+      <BottomActions />
     </div>
   );
 };

--- a/src/pages/DetailPage/index.tsx
+++ b/src/pages/DetailPage/index.tsx
@@ -27,7 +27,7 @@ const DetailPage = () => {
           <PostContent itemInfo={data.itemInfo} />
         </div>
       </div>
-      <BottomActions />
+      <BottomActions itemInfo={data.itemInfo} />
     </div>
   );
 };


### PR DESCRIPTION
## ❗ 연관 이슈

- Resolves #63 
<!-- 관련된 이슈가 있다면 작성해주세요. ex) - #이슈번호 -->

## 📌 내용

- 짜잔
	- 왼쪽부터 차례로 `내꺼`, `남꺼인데 구매만 있는 케이스`, `남꺼인데 둘 다 있는 케이스`
	- 일단 페이지 넘어가는건 구현 안해뒀고 alert으로 피드백만 주게 해놨음요
	- 아마 `모든걸테스트해보기위한게시글` 들어가면 가격이 깨질텐데 이것 역시 가격 상한 생기면 괜춘할듯

<img height="300" alt="Screenshot 2025-07-18 at 8 16 18 PM" src="https://github.com/user-attachments/assets/24c57934-908d-4823-b622-991b006f58db" />
<img height="300" alt="Screenshot 2025-07-18 at 8 16 38 PM" src="https://github.com/user-attachments/assets/20d01945-06e4-4293-aa3d-38dc5a95a88a" />
<img height="300" alt="Screenshot 2025-07-18 at 8 17 25 PM" src="https://github.com/user-attachments/assets/8e2d4e13-6a8b-4be8-9a6b-7a38f4b8e00e" />



<!-- PR에 대한 소개와, 어떤 기능 / 어떤 버그 픽스 구현이 있는지 설명해주세요.
논의가 필요한 지점이나 고려할 점이 있다면 작성해주세요. -->

## ☑️ 체크 사항 & 논의 사항

<!-- 체크해봐야할 지점을 작성해주세요. -->

- `yarn` 한번 하고 돌려보기
- [ ] 피그마랑 디자인이 같은가 흠
	- 게시글이랑 겹쳐지는 부분 그라데이션 들어간 디자인이 피그마에는 대여제품상세 첫 프레임에만 적용되어 있어요. 이거 참고해서 봐주삼