### PR TITLE
[#100] 바뀐 API 대응!!!!!!!!!

### DIFF
--- a/src/common/utils/getImageUrl.ts
+++ b/src/common/utils/getImageUrl.ts
@@ -2,7 +2,11 @@ const getImageUrl = (imageUrl: string) => {
   if (imageUrl.startsWith('http')) {
     return imageUrl;
   }
-  return `${import.meta.env.VITE_IMAGE_PREFIX_URL}/${imageUrl}`;
+  const prefixUrl = import.meta.env.VITE_IMAGE_PREFIX_URL || '';
+  if (!prefixUrl) {
+    throw new Error('VITE_IMAGE_PREFIX_URL is not defined or is empty.');
+  }
+  return `${prefixUrl}/${imageUrl}`;
 };
 
 export default getImageUrl;

--- a/src/common/utils/getImageUrl.ts
+++ b/src/common/utils/getImageUrl.ts
@@ -1,0 +1,8 @@
+const getImageUrl = (imageUrl: string) => {
+  if (imageUrl.startsWith('http')) {
+    return imageUrl;
+  }
+  return `${import.meta.env.VITE_IMAGE_PREFIX_URL}/${imageUrl}`;
+};
+
+export default getImageUrl;

--- a/src/features/detail/components/ImageContainer/index.tsx
+++ b/src/features/detail/components/ImageContainer/index.tsx
@@ -4,6 +4,7 @@ import { Swiper, SwiperSlide } from 'swiper/react';
 import * as s from './style.css';
 import { Zoom } from 'swiper/modules';
 import StepIndicator from '@/features/detail/components/StepIndicator';
+import getImageUrl from '@/common/utils/getImageUrl';
 
 interface Props {
   images: string[];
@@ -26,7 +27,7 @@ const ImageContainer = ({ images }: Props) => {
         {images.map((image, index) => (
           <SwiperSlide key={`${image}-${index}`}>
             <div className="swiper-zoom-container">
-              <img className={s.Image} src={image} aria-hidden />
+              <img className={s.Image} src={getImageUrl(image)} aria-hidden />
             </div>
           </SwiperSlide>
         ))}

--- a/src/features/home/apis/useGetItemList.ts
+++ b/src/features/home/apis/useGetItemList.ts
@@ -5,26 +5,33 @@ import type { ItemInterface, ItemOrderType } from '@/features/home/types';
 import type { Color, ProductType, Size, TradeMethods, TransactionType } from '@/libs/types/item';
 
 export interface ItemListRequest {
+  pageSize: number;
+  itemOrder?: ItemOrderType;
+  startDate?: string;
+  endDate?: string;
+  startPrice?: number;
+  endPrice?: number;
+  cursorId?: number;
+  cursorValue?: number;
+  cursorDate?: string;
   keyword?: string;
   productTypes?: ProductType[];
   transactionTypes?: TransactionType[];
   sizes?: Size[];
   colors?: Color[];
   tradeMethods?: TradeMethods[];
-  date?: string;
-  itemOrder?: ItemOrderType;
 }
 export interface ItemListResponse {
   message: string;
   data: { items: ItemInterface[]; totalCount: number };
 }
 
-const getItemList = async (params?: ItemListRequest) => {
+const getItemList = async (params: ItemListRequest) => {
   const response = await client.get<ItemListResponse>('/api/v1/item/search', { params });
   return response.data;
 };
 
-export const useGetItemList = (params?: ItemListRequest) => {
+export const useGetItemList = (params: ItemListRequest) => {
   return useQuery({
     queryKey: ['item-list', params],
     queryFn: () => getItemList(params),

--- a/src/features/home/components/ItemCard/index.tsx
+++ b/src/features/home/components/ItemCard/index.tsx
@@ -5,6 +5,7 @@ import * as s from './style.css';
 import type { ItemInterface } from '@/features/home/types';
 import ItemTokenList from '@/common/components/ItemTokenList';
 import PriceToken from '@/features/home/components/ItemCard/PriceToken';
+import getImageUrl from '@/common/utils/getImageUrl';
 
 interface Props {
   data: ItemInterface;
@@ -15,7 +16,7 @@ const ItemCard = ({ data }: Props) => {
 
   return (
     <Link className={s.Container} to={`/detail/${data.itemId}`}>
-      <img className={s.Image} src={data.thumbnail} aria-hidden />
+      <img className={s.Image} src={getImageUrl(data.thumbnail)} aria-hidden />
       <div className={s.Info}>
         <div className={s.Header}>
           <h2 className={s.Title}>{data.title}</h2>

--- a/src/features/home/components/RecentList/index.tsx
+++ b/src/features/home/components/RecentList/index.tsx
@@ -2,9 +2,10 @@ import * as s from './style.css';
 
 import { useGetItemList } from '@/features/home/apis/useGetItemList';
 import ItemList from '@/features/home/components/ItemList';
+import { ITEM_PAGING_SIZE } from '@/libs/constants';
 
 const RecentList = () => {
-  const { data: itemList } = useGetItemList();
+  const { data: itemList } = useGetItemList({ pageSize: ITEM_PAGING_SIZE });
 
   return (
     <div className={s.Wrapper}>

--- a/src/libs/constants/index.ts
+++ b/src/libs/constants/index.ts
@@ -6,3 +6,5 @@ export const ALLOWED_EXTENSIONS = ['jpg', 'jpeg', 'png', 'webp'];
 export const MAX_SIZE_MB = 5;
 export const MAX_SIZE_BYTES = MAX_SIZE_MB * 1024 * 1024;
 export const MAX_FILE_LENGTH = 6;
+
+export const ITEM_PAGING_SIZE = 20;

--- a/src/pages/SearchPage/index.tsx
+++ b/src/pages/SearchPage/index.tsx
@@ -9,18 +9,20 @@ import { useGetItemList } from '@/features/home/apis/useGetItemList';
 import type { ItemOrderType } from '@/features/home/types';
 import type { Color, ProductType, Size, TradeMethods, TransactionType } from '@/libs/types/item';
 import ItemList from '@/features/home/components/ItemList';
+import { ITEM_PAGING_SIZE } from '@/libs/constants';
 
 const SearchPage = () => {
   const [searchParams] = useSearchParams();
   const { data: searchData } = useGetItemList({
+    pageSize: ITEM_PAGING_SIZE,
     keyword: searchParams.get('keyword') || undefined,
     productTypes: searchParams.getAll('product-type') as ProductType[],
     colors: searchParams.getAll('color') as Color[],
     sizes: searchParams.getAll('size') as Size[],
     itemOrder: searchParams.get('item-order') as ItemOrderType,
     transactionTypes: searchParams.getAll('transaction-type') as TransactionType[],
-    date: searchParams.get('date') || undefined,
     tradeMethods: searchParams.getAll('trade-method') as TradeMethods[],
+    // date: searchParams.get('date') || undefined,
   });
 
   return (


### PR DESCRIPTION
## ❗ 연관 이슈

- Resolves #100 
<!-- 관련된 이슈가 있다면 작성해주세요. ex) - #이슈번호 -->

## 📌 내용

- 검색 API Request가 바뀌어서 그에 맞게 인터페이스를 갈아끼웠습니다
	- 아마 다른 브랜치에서는 아이템 목록들이 펑펑 터지면서 안 보일거라 이거 합친 이후에 리베해주세요
	- 근데 DB 초기화된거 같음 게시물 다 날아감 ㅠㅠㅠ
- 이미지 링크 내려오는 것도 저번 회의때 말한거처럼 바뀌어서 이제 프론트에서 base url을 결합해주어야 합니다
	- 이 로직은 getImageUrl 유틸함수 만들어서 구현해놨어요

<!-- PR에 대한 소개와, 어떤 기능 / 어떤 버그 픽스 구현이 있는지 설명해주세요.
논의가 필요한 지점이나 고려할 점이 있다면 작성해주세요. -->

## ☑️ 체크 사항 & 논의 사항

<!-- 체크해봐야할 지점을 작성해주세요. -->

- .env파일에 다음 줄 추가하기
```
VITE_IMAGE_PREFIX_URL=https://d2igvm09q9l6tz.cloudfront.net
```