### PR TITLE
소소한 수정 (1분 PR 가능)

### DIFF
--- a/src/features/detail/components/BottomActions/style.css.ts
+++ b/src/features/detail/components/BottomActions/style.css.ts
@@ -1,7 +1,7 @@
 import { css, cva } from '@styled-system/css';
 
 export const Container = css({
-  position: 'fixed',
+  position: 'absolute',
   bottom: '0',
   left: '0',
   right: '0',

--- a/src/pages/DetailPage/style.css.ts
+++ b/src/pages/DetailPage/style.css.ts
@@ -8,9 +8,9 @@ export const Container = css({
 
 export const ScrollContainer = css({
   width: 'full',
-  height: 'full',
+  height: 'calc(100% - {sizes.DETAIL_PAGE_NAVIGATOR_HEIGHT})',
   overflowY: 'auto',
-  paddingBottom: 'DETAIL_PAGE_NAVIGATOR_HEIGHT',
+  paddingBottom: '1rem',
 });
 
 export const ContentContainer = css({

--- a/src/pages/routes.tsx
+++ b/src/pages/routes.tsx
@@ -24,10 +24,6 @@ const routes: RouteObject[] = [
         element: <HomePage />,
       },
       {
-        path: '/pick',
-        element: <PickPage />,
-      },
-      {
         path: '/detail/:id',
         element: <DetailPage />,
       },


### PR DESCRIPTION
## ❗ 연관 이슈

- Resolves #111 
- Resolves #110 
<!-- 관련된 이슈가 있다면 작성해주세요. ex) - #이슈번호 -->

## 📌 내용

- 디테일 페이지 하단 바가 데스크탑에서 개크게 나오는 버그 수정
- 디테일 페이지 스크롤이 있는 경우에 하단바를 넘어서서 겹쳐지는 버그 수정
- Pick Page 라우트 수정, 이제 핔페이지 접속하려고 하면 로그인하라고 나옴

> Before
<img width="600" alt="Screenshot 2025-08-01 at 4 02 14 PM" src="https://github.com/user-attachments/assets/c5998782-b06d-41b8-882c-14ce50e47d9e" />


> After
<img width="600" alt="Screenshot 2025-08-01 at 4 02 45 PM" src="https://github.com/user-attachments/assets/f551de40-04c6-4b08-97c3-c4933d46bd23" />
