### PR TITLE
feat: header logo & drop search icon

### DIFF
--- a/src/common/components/MainTopBar/index.tsx
+++ b/src/common/components/MainTopBar/index.tsx
@@ -2,19 +2,20 @@ import { Link } from 'react-router';
 import * as s from './style.css';
 
 import RepickaTitle from '@/libs/assets/RepickaTitle';
+import RepickaLogo from '@/libs/assets/RepickaLogo';
 
 const MainTopBar = () => {
   return (
     <div className={s.Wrapper}>
       <Link className={s.Title} to={'/'}>
         {/* TODO: 실제 로고 넣기 ! */}
-        <div className={s.Logo} />
+        <span className={s.LogoContainer}>
+          <RepickaLogo />
+        </span>
         <RepickaTitle />
       </Link>
       <div className={s.Menu}>
-        {/* TODO: 링크 연결하기 */}
         <Link className="mgc_search_2_fill" to={'/search'} />
-        <button className="mgc_chat_3_fill" />
         <button className="mgc_notification_fill" />
       </div>
     </div>

--- a/src/common/components/MainTopBar/style.css.ts
+++ b/src/common/components/MainTopBar/style.css.ts
@@ -21,13 +21,6 @@ export const LogoContainer = css({
   height: '1.5rem',
 });
 
-export const Logo = css({
-  width: '1.5rem',
-  height: '1.5rem',
-  bgColor: '100',
-  rounded: '3.2px',
-});
-
 export const Menu = css({
   display: 'flex',
   alignItems: 'center',

--- a/src/common/components/MainTopBar/style.css.ts
+++ b/src/common/components/MainTopBar/style.css.ts
@@ -16,6 +16,11 @@ export const Title = css({
   color: '100',
 });
 
+export const LogoContainer = css({
+  width: '1.5rem',
+  height: '1.5rem',
+});
+
 export const Logo = css({
   width: '1.5rem',
   height: '1.5rem',

--- a/src/libs/assets/RepickaLogo.tsx
+++ b/src/libs/assets/RepickaLogo.tsx
@@ -1,0 +1,46 @@
+const RepickaLogo = () => {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" fill="none" viewBox="0 0 24 25">
+      <rect width="24" height="24" y="0.143" fill="#1C1C1E" rx="4"></rect>
+      <path
+        fill="url(#paint0_linear_2760_4935)"
+        d="M12.056 21.562c-.456.089-.933-.336-1.093-.978L7.337 6.073c-.473-1.764.215-2.928 1.273-3.133 1.08-.21 2.119.457 2.363 2.507l1.736 14.837c.075.64-.207 1.192-.653 1.278"
+      ></path>
+      <path
+        fill="#F83E00"
+        d="M4.666 18.663c-.388-.436-.27-1.193.278-1.738L17.287 4.6c1.737-1.614 3.11-1.475 4.01-.464.918 1.032.962 2.557-.998 3.985L6.389 18.617c-.6.453-1.344.473-1.723.046"
+      ></path>
+      <path
+        fill="url(#paint1_linear_2760_4935)"
+        d="M1.984 9.905c.226-.539.955-.76 1.676-.506l16.313 5.738c2.286.791 2.649 2.155 2.126 3.404-.533 1.274-1.722 2.064-3.997.835l-15.34-7.942c-.663-.343-.998-1.003-.778-1.53"
+      ></path>
+      <defs>
+        <linearGradient
+          id="paint0_linear_2760_4935"
+          x1="11.919"
+          x2="8.795"
+          y1="21.309"
+          y2="3.255"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#F83E00" stopOpacity="0.5"></stop>
+          <stop offset="0.5" stopColor="#F83E00"></stop>
+          <stop offset="1" stopColor="#F83E00" stopOpacity="0.5"></stop>
+        </linearGradient>
+        <linearGradient
+          id="paint1_linear_2760_4935"
+          x1="2.319"
+          x2="21.701"
+          y1="9.928"
+          y2="18.462"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#F83E00" stopOpacity="0.5"></stop>
+          <stop offset="0.5" stopColor="#F83E00"></stop>
+          <stop offset="1" stopColor="#F83E00" stopOpacity="0.5"></stop>
+        </linearGradient>
+      </defs>
+    </svg>
+  );
+};
+export default RepickaLogo;


### PR DESCRIPTION
## 📌 내용

<img width="329" height="721" alt="Screenshot 2025-08-24 at 11 58 42 PM" src="https://github.com/user-attachments/assets/baf56925-b41d-432a-8a38-7890be85cf3f" />


- 헤더에 로고 적용
- 헤더에서 채팅 아이콘 삭제
<!-- PR에 대한 소개와, 어떤 기능 / 어떤 버그 픽스 구현이 있는지 설명해주세요.
논의가 필요한 지점이나 고려할 점이 있다면 작성해주세요. -->